### PR TITLE
Automatically delete unlimited invites

### DIFF
--- a/bot/inviting.py
+++ b/bot/inviting.py
@@ -29,11 +29,11 @@ async def on_ready(bot):
 async def on_member_remove(member):
     #Update cache
     invite_cache[member.guild.id] = await member.guild.invites()
-        
+
 #Delete any invite which is not single-use
 async def on_invite_create(invite):
     if invite.max_uses != 1:
-        await invite.delete("Automatic deletion, non-single use invite created")
+        await invite.delete(reason='Automatic deletion, non-single use invite created')
 
 #Should be called from within on_member_join
 async def fetch_inviter(member):

--- a/bot/inviting.py
+++ b/bot/inviting.py
@@ -29,6 +29,11 @@ async def on_ready(bot):
 async def on_member_remove(member):
     #Update cache
     invite_cache[member.guild.id] = await member.guild.invites()
+        
+#Delete any invite which is not single-use
+async def on_invite_create(invite):
+    if invite.max_uses != 1:
+        await invite.delete("Automatic deletion, non-single use invite created")
 
 #Should be called from within on_member_join
 async def fetch_inviter(member):

--- a/bot/inviting.py
+++ b/bot/inviting.py
@@ -30,10 +30,10 @@ async def on_member_remove(member):
     #Update cache
     invite_cache[member.guild.id] = await member.guild.invites()
 
-#Delete any invite which is not single-use
+#Delete any invite which does not expire after 30 minutes
 async def on_invite_create(invite):
-    if invite.max_uses != 1:
-        await invite.delete(reason='Automatic deletion, non-single use invite created')
+    if invite.max_age > 1800:
+        await invite.delete(reason='Automatic deletion, invite expiration was set to >30 minutes.')
 
 #Should be called from within on_member_join
 async def fetch_inviter(member):

--- a/bot/main.py
+++ b/bot/main.py
@@ -422,6 +422,10 @@ async def on_member_join(member):
 async def on_member_remove(member):
   await inviting.on_member_remove(member)
 
+@bot.event
+async def on_invite_create(invite):
+  await inviting.on_invite_create(invite)
+
 #Generic error handling
 @bot.event
 async def on_command_error(ctx, error):


### PR DESCRIPTION
Initially I had the idea of deleting anything that's not single-use but that can't be tracked, so here's something to delete any invite that has expiration set to more than 30 minutes.
A few potential problems/ideas:

- Should the bot DM the user or send a message in the server with a mention telling them the invite was deleted,
- Should there be an admin-only command which can create an unlimited invite _(this is in case something happens to the backup unlimited invite, so the bot does not prevent creation of a new one)_,
- Should there be a variable in the .env file which sets the maximum invite expiration time?

Tell me if I should add any of these.